### PR TITLE
Remove obfusication

### DIFF
--- a/lib/s3_backup/pg/backup.rb
+++ b/lib/s3_backup/pg/backup.rb
@@ -31,7 +31,7 @@ module S3Backup
       end
 
       def dump_database
-        `pg_dump -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
+        `pg_dump -Fc -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
 
         abort "Failed to complete pg_dump. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end

--- a/lib/s3_backup/pg/backup.rb
+++ b/lib/s3_backup/pg/backup.rb
@@ -14,7 +14,7 @@ module S3Backup
         dump_database
         puts 'Dump downloaded.'
         puts 'Upload to S3 ...'
-        S3Backup::Storage::S3.new.upload!(File.basename(pg_dump_file), Config.s3_pg_path, pg_dump_file.path)
+        S3Backup::Storage::S3.new.upload!(obfucated_file_name, Config.s3_pg_path, pg_dump_file.path)
         puts 'Uploaded.'
         puts 'Cleaning up environment...'
         clean_env
@@ -36,6 +36,10 @@ module S3Backup
 
       def pg_dump_file
         @pg_dump_file ||= Tempfile.new(db_name)
+      end
+
+      def obfucated_file_name
+        @obfucated_file_name ||= "#{db_name}-#{Time.now.to_i}.gz"
       end
 
       def clean_env

--- a/lib/s3_backup/pg/backup.rb
+++ b/lib/s3_backup/pg/backup.rb
@@ -38,7 +38,7 @@ module S3Backup
         @pg_dump_file ||= Tempfile.new(db_name)
       end
 
-     def clean_env
+      def clean_env
         pg_dump_file.unlink
         ENV['PGPASSWORD'] = ''
       end

--- a/lib/s3_backup/pg/backup.rb
+++ b/lib/s3_backup/pg/backup.rb
@@ -31,7 +31,7 @@ module S3Backup
       end
 
       def dump_database
-        `pg_dump -Z9 -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
+        `pg_dump -Fc -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
 
         abort "Failed to complete pg_dump. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end

--- a/lib/s3_backup/pg/backup.rb
+++ b/lib/s3_backup/pg/backup.rb
@@ -29,9 +29,9 @@ module S3Backup
       end
 
       def dump_database
-        `pg_dump -Fc -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
+        `pg_dump -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} | gzip > #{pg_dump_file.path}`
 
-        abort "Failed to complete pg_dump. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
+        abort "Failed to pg_dump. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end
 
       def pg_dump_file

--- a/lib/s3_backup/pg/backup.rb
+++ b/lib/s3_backup/pg/backup.rb
@@ -8,7 +8,7 @@ module S3Backup
       end
 
       def now!
-        puts 'Setup environement'
+        puts 'Setup environment'
         set_pg_password_env
         puts 'Starting downloading dump ...'
         dump_database
@@ -19,7 +19,7 @@ module S3Backup
         puts 'Upload to S3 ...'
         S3Backup::Storage::S3.new.upload!(obfucated_file_name, Config.s3_pg_path, obfuscated_file.path)
         puts 'Uploaded.'
-        puts 'Clean environement.'
+        puts 'Clean environment.'
         clean_env
         S3Backup::Storage::S3.new.clean!(db_name, Config.s3_pg_path)
       end
@@ -31,7 +31,7 @@ module S3Backup
       end
 
       def dump_database
-        `pg_dump -Fc -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
+        `pg_dump -Z9 -h #{Config.pg_host} -U #{Config.pg_user} -d #{db_name} > #{pg_dump_file.path}`
 
         abort "Failed to complete pg_dump. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end

--- a/lib/s3_backup/pg/import.rb
+++ b/lib/s3_backup/pg/import.rb
@@ -44,7 +44,7 @@ module S3Backup
       end
 
       def load_file
-        `psql -d #{database} -f #{pg_dump_file.path} 2> /dev/null`
+        `pg_restore -d #{database} < #{pg_dump_file.path}`
       end
 
       def setup_local_database

--- a/lib/s3_backup/pg/import.rb
+++ b/lib/s3_backup/pg/import.rb
@@ -34,9 +34,11 @@ module S3Backup
                   WHERE pg_stat_activity.datname = '#{database}' \
                   AND pid <> pg_backend_pid();" #{database}`
 
+        abort "Failed to complete pg_terminate_backend. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
+
         `pg_restore -j 2 -O -c -d #{database} < #{pg_dump_s3_file.path}`
 
-        abort "Failed to complete pg_restore. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
+        abort "Failed to pg_restore. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end
 
       def clean_env

--- a/lib/s3_backup/pg/import.rb
+++ b/lib/s3_backup/pg/import.rb
@@ -29,6 +29,11 @@ module S3Backup
       end
 
       def load_file
+        `psql -c "SELECT pg_terminate_backend(pg_stat_activity.pid) \
+                  FROM pg_stat_activity \
+                  WHERE pg_stat_activity.datname = '#{database}' \
+                  AND pid <> pg_backend_pid();" #{database}`
+
         `pg_restore -j 2 -O -c -d #{database} < #{pg_dump_s3_file.path}`
 
         abort "Failed to complete pg_restore. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0

--- a/lib/s3_backup/pg/import.rb
+++ b/lib/s3_backup/pg/import.rb
@@ -36,7 +36,7 @@ module S3Backup
 
         abort "Failed to complete pg_terminate_backend. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
 
-        `pg_restore -j 2 -O -c -d #{database} < #{pg_dump_s3_file.path}`
+        `pg_restore -j 2 -O -c -d #{database} #{pg_dump_s3_file.path}`
 
         abort "Failed to pg_restore. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end

--- a/lib/s3_backup/pg/import.rb
+++ b/lib/s3_backup/pg/import.rb
@@ -29,7 +29,7 @@ module S3Backup
       end
 
       def load_file
-        `pg_restore -O -c -d #{database} < #{pg_dump_s3_file.path}`
+        `pg_restore -j 2 -O -c -d #{database} < #{pg_dump_s3_file.path}`
 
         abort "Failed to complete pg_restore. Return code #{$CHILD_STATUS}" unless $CHILD_STATUS == 0
       end

--- a/lib/tasks/pg.rake
+++ b/lib/tasks/pg.rake
@@ -21,7 +21,7 @@ namespace :s3_backup do
     task :download, [:pg_database,:filename] do |_task, args|
       raise 'You need to specify a pg database' unless args[:pg_database]
       filename = args[:filename] || "/tmp/#{pg_database_name}-#{Time.current.strftime('%Y%m%dT%H%M%S')}.sql.gz"
-      
+
       S3Backup.pg_download! args[:pg_database], filename
       puts "Downloaded backup to #{filename}"
     end


### PR DESCRIPTION
Two main changes:

* Remove obfuscation because (i) we don't use it and (ii) it's very expensive in terms of disk space to dump the plain text SQL, obfuscate it and the gzip it.
* Introduce logic to drop connections before dropping the database (before importing the dump)